### PR TITLE
:sparkles: Added support for GCC versions 13.2, 13.3, and 14.2

### DIFF
--- a/.github/workflows/13.2.yml
+++ b/.github/workflows/13.2.yml
@@ -1,0 +1,15 @@
+name: 🚀 13.2 Deploy
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      version: "13.2"
+    secrets: inherit

--- a/.github/workflows/13.3.yml
+++ b/.github/workflows/13.3.yml
@@ -1,0 +1,15 @@
+name: 🚀 13.3 Deploy
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      version: "13.3"
+    secrets: inherit

--- a/.github/workflows/14.2.yml
+++ b/.github/workflows/14.2.yml
@@ -1,0 +1,15 @@
+name: 🚀 14.2 Deploy
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      version: "14.2"
+    secrets: inherit

--- a/all/conandata.yml
+++ b/all/conandata.yml
@@ -94,7 +94,7 @@ sources:
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
         sha256": "e46fda043c0ce83582bc8db4b3ef85f77f4beb7333344c2f4193c17e1167a095"
-    "14.2":
+  "14.2":
     "Linux":
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz"

--- a/all/conandata.yml
+++ b/all/conandata.yml
@@ -56,3 +56,60 @@ sources:
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
         sha256: "d52888bf59c5262ebf3e6b19b9f9e6270ecb60fd218cf81a4e793946e805a654"
+  "13.2":
+    "Linux":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz"
+        sha256: "6cd1bbc1d9ae57312bcd169ae283153a9572bd6a8e4eeae2fedfbc33b115fdbb"
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-aarch64-aarch64-none-elf.tar.xz"
+        sha256: "f3871c0d91a7375834eb43eb758f4df6d8dadf20ad9deca2eb569d5599d98e89"
+    "MacOS":
+      x86_64:
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-x86_64-aarch64-none-elf.tar.xz"
+        sha256: "8473b67285af0f883004e5364c835b43af8d83ed148f493dd21c4c1067b1a0a8"
+      armv8:
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-arm64-arm-none-eabi.tar.xz"
+        sha256: "39c44f8af42695b7b871df42e346c09fee670ea8dfc11f17083e296ea2b0d279"
+    "Windows":
+      "x86_64":
+        url: "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip"
+        sha256": "51d933f00578aa28016c5e3c84f94403274ea7915539f8e56c13e2196437d18f"
+  "13.3":
+    "Linux":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz"
+        sha256: "95c011cee430e64dd6087c75c800f04b9c49832cc1000127a92a97f9c8d83af4"
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-aarch64-arm-none-eabi.tar.xz"
+        sha256: "c8824bffd057afce2259f7618254e840715f33523a3d4e4294f471208f976764"
+    "MacOS":
+      x86_64:
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
+        sha256: "1ab00742d1ed0926e6f227df39d767f8efab46f5250505c29cb81f548222d794"
+      armv8:
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi.tar.xz"
+        sha256: "fb6921db95d345dc7e5e487dd43b745e3a5b4d5c0c7ca4f707347148760317b4"
+    "Windows":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
+        sha256": "e46fda043c0ce83582bc8db4b3ef85f77f4beb7333344c2f4193c17e1167a095"
+    "14.2":
+    "Linux":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz"
+        sha256: "62a63b981fe391a9cbad7ef51b17e49aeaa3e7b0d029b36ca1e9c3b2a9b78823"
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-aarch64-arm-none-eabi.tar.xz"
+        sha256: "87330bab085dd8749d4ed0ad633674b9dc48b237b61069e3b481abd364d0a684"
+    "MacOS":
+      x86_64:
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
+        sha256: "2d9e717dd4f7751d18936ae1365d25916534105ebcb7583039eff1092b824505"
+      armv8:
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-darwin-arm64-arm-none-eabi.tar.xz"
+        sha256: "c7c78ffab9bebfce91d99d3c24da6bf4b81c01e16cf551eb2ff9f25b9e0a3818"
+    "Windows":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-mingw-w64-i686-arm-none-eabi.zip"
+        sha256": "6facb152ce431ba9a4517e939ea46f057380f8f1e56b62e8712b3f3b87d994e1"

--- a/all/conandata.yml
+++ b/all/conandata.yml
@@ -74,7 +74,7 @@ sources:
     "Windows":
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip"
-        sha256": "51d933f00578aa28016c5e3c84f94403274ea7915539f8e56c13e2196437d18f"
+        sha256: "51d933f00578aa28016c5e3c84f94403274ea7915539f8e56c13e2196437d18f"
   "13.3":
     "Linux":
       "x86_64":
@@ -93,7 +93,7 @@ sources:
     "Windows":
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
-        sha256": "e46fda043c0ce83582bc8db4b3ef85f77f4beb7333344c2f4193c17e1167a095"
+        sha256: "e46fda043c0ce83582bc8db4b3ef85f77f4beb7333344c2f4193c17e1167a095"
   "14.2":
     "Linux":
       "x86_64":
@@ -112,4 +112,4 @@ sources:
     "Windows":
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-mingw-w64-i686-arm-none-eabi.zip"
-        sha256": "6facb152ce431ba9a4517e939ea46f057380f8f1e56b62e8712b3f3b87d994e1"
+        sha256: "6facb152ce431ba9a4517e939ea46f057380f8f1e56b62e8712b3f3b87d994e1"

--- a/all/conandata.yml
+++ b/all/conandata.yml
@@ -62,18 +62,18 @@ sources:
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz"
         sha256: "6cd1bbc1d9ae57312bcd169ae283153a9572bd6a8e4eeae2fedfbc33b115fdbb"
       "armv8":
-        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-aarch64-aarch64-none-elf.tar.xz"
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-aarch64-arm-none-eabi.tar.xz"
         sha256: "f3871c0d91a7375834eb43eb758f4df6d8dadf20ad9deca2eb569d5599d98e89"
-    "MacOS":
+    "Macos":
       x86_64:
-        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-x86_64-aarch64-none-elf.tar.xz"
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
         sha256: "8473b67285af0f883004e5364c835b43af8d83ed148f493dd21c4c1067b1a0a8"
       armv8:
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-arm64-arm-none-eabi.tar.xz"
         sha256: "39c44f8af42695b7b871df42e346c09fee670ea8dfc11f17083e296ea2b0d279"
     "Windows":
       "x86_64":
-        url: "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip"
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip"
         sha256": "51d933f00578aa28016c5e3c84f94403274ea7915539f8e56c13e2196437d18f"
   "13.3":
     "Linux":
@@ -83,7 +83,7 @@ sources:
       "armv8":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-aarch64-arm-none-eabi.tar.xz"
         sha256: "c8824bffd057afce2259f7618254e840715f33523a3d4e4294f471208f976764"
-    "MacOS":
+    "Macos":
       x86_64:
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
         sha256: "1ab00742d1ed0926e6f227df39d767f8efab46f5250505c29cb81f548222d794"
@@ -102,7 +102,7 @@ sources:
       "armv8":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-aarch64-arm-none-eabi.tar.xz"
         sha256: "87330bab085dd8749d4ed0ad633674b9dc48b237b61069e3b481abd364d0a684"
-    "MacOS":
+    "Macos":
       x86_64:
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
         sha256: "2d9e717dd4f7751d18936ae1365d25916534105ebcb7583039eff1092b824505"

--- a/conan/profiles/v1/arm-gcc-13.2
+++ b/conan/profiles/v1/arm-gcc-13.2
@@ -1,0 +1,8 @@
+[settings]
+compiler=gcc
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+compiler.version=13.2
+
+[tool_requires]
+arm-gnu-toolchain/13.2

--- a/conan/profiles/v1/arm-gcc-13.3
+++ b/conan/profiles/v1/arm-gcc-13.3
@@ -1,0 +1,8 @@
+[settings]
+compiler=gcc
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+compiler.version=13.3
+
+[tool_requires]
+arm-gnu-toolchain/13.3

--- a/conan/profiles/v1/arm-gcc-14.2
+++ b/conan/profiles/v1/arm-gcc-14.2
@@ -1,0 +1,8 @@
+[settings]
+compiler=gcc
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+compiler.version=14.2
+
+[tool_requires]
+arm-gnu-toolchain/14.2

--- a/config.yml
+++ b/config.yml
@@ -5,3 +5,9 @@ versions:
     folder: "all"
   "12.3":
     folder: "all"
+  "13.2":
+    folder: "all"
+  "13.3":
+    folder: "all"
+  "14.2":
+    folder: "all"


### PR DESCRIPTION
Updated conan profiles, github workflows, and conandata.yml for adding GCC versions.