### PR TITLE
make gcc the assembler to allow for preprocessing

### DIFF
--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -162,7 +162,7 @@ class ArmGnuToolchain(ConanFile):
         self.conf_info.define("tools.build:compiler_executables", {
             "c": "arm-none-eabi-gcc",
             "cpp": "arm-none-eabi-g++",
-            "asm": "arm-none-eabi-as",
+            "asm": "arm-none-eabi-gcc",
         })
 
         f = os.path.join(self.package_folder, "res/toolchain.cmake")


### PR DESCRIPTION
The Raspberry Pi Pico C SDK uses .S files in the crt0 implementation. This requires preprocessing by `cpp`, which is handled by using `gcc` instead of the assembler directly.