### PR TITLE
:construction_worker: Centralize CI

### DIFF
--- a/.github/workflows/11.3.yml
+++ b/.github/workflows/11.3.yml
@@ -2,10 +2,7 @@ name: 🚀 11.3 Deploy
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/12.2.yml
+++ b/.github/workflows/12.2.yml
@@ -2,10 +2,7 @@ name: 🚀 12.2 Deploy
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/12.3.yml
+++ b/.github/workflows/12.3.yml
@@ -2,10 +2,7 @@ name: 🚀 12.3 Deploy
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: ✅ CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci_11_3:
+    uses: ./.github/workflows/11.3.yml
+    secrets: inherit
+  ci_12_2:
+    uses: ./.github/workflows/12.2.yml
+    secrets: inherit
+  ci_12_3:
+    uses: ./.github/workflows/12.3.yml
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-12, windows-2022]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Use a single ci.yml script to centralize CI to a single action. This
makes starting, stopping, and restarting actions generated from a PR
easier to manage.

Removing deprecated Ubuntu 20.04 support.