### PR TITLE
:sparkles: Support local toolchain paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: 📥 Install CMake & Conan
-        run: pip3 install conan==2.16.1
+        run: pipx install conan==2.16.1
 
       - name: 📡 Add `libhal` conan remote
         run: |


### PR DESCRIPTION
Now, if you are testing your own build of the ARM GNU Toolchain, you can make it into a conan package by simply setting the correct version and supplying the local_path option like so:

```
conan create all --version 13.3 -o "*:local_path=/path/to/build-arm-none-eabi/install"
```