### PR TITLE
:fire: Remove default_specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,16 +176,6 @@ target profile.
 For `cortex-m4`, the flags would be `-mcpu=cortex-m4` and `-mfloat-abi=soft`.
 For `cortex-m4f`, the flags would be `-mcpu=cortex-m4` and `-mfloat-abi=hard`.
 
-### `default_specs` (Default: `True`)
-
-This option can be `True` or `False` and when set to `True` will inject the
-`--specs=nano.specs` `--specs=nosys.specs` into the linker flags. With these
-two newlib C specifications most C and C++ projects should build without
-linking errors. `--specs=nosys.specs` defines stubs for the low level system
-libc APIs like `_write`, `_read`, `_sbrk()`, and `_get_pid()`.
-`--specs=nano.specs` provides base implementations of things such as `printf`
-and `malloc`.
-
 ### `lto` (Default: `True`)
 
 This option can be `True` or `False` and when set to `True` will inject the

--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -27,7 +27,6 @@ class ArmGnuToolchain(ConanFile):
     options = {
         "local_path": ["ANY"],
         "default_arch": [True, False],
-        "default_specs": [True, False],
         "lto": [True,  False],
         "fat_lto": [True,  False],
         "function_sections": [True,  False],
@@ -38,7 +37,6 @@ class ArmGnuToolchain(ConanFile):
     default_options = {
         "local_path": "",
         "default_arch": True,
-        "default_specs": True,
         "lto": True,
         "fat_lto": True,
         "function_sections": True,
@@ -49,7 +47,6 @@ class ArmGnuToolchain(ConanFile):
     options_description = {
         "local_path": "Provide a path to your local ARM GNU Toolchain. If not set, the official toolchain is downloaded from the ARM website.",
         "default_arch": "Automatically inject architecture appropriate the -mcpu and -mfloat-abi arguments into compilation flags.",
-        "default_specs": "Inject --specs=nano.specs & --specs=nosys.specs into the link flags which allows programs with no specs specified to compile like test packages.",
         "lto": "Enable LTO support in binaries and intermediate files (.o and .a files)",
         "fat_lto": "Enable linkers without LTO support to still build with LTO enabled binaries. This adds both LTO information and compiled code into the object and archive files.",
         "function_sections": "Enable -ffunction-sections which splits each function into their own subsection allowing link time garbage collection of the sections.",
@@ -223,10 +220,6 @@ class ArmGnuToolchain(ConanFile):
             c_flags.append("-fdata-sections")
             cxx_flags.append("-fdata-sections")
 
-        if self.options.default_specs:
-            exelinkflags.append("--specs=nano.specs")
-            exelinkflags.append("--specs=nosys.specs")
-
         if self.options.gc_sections:
             exelinkflags.append("-Wl,--gc-sections")
 
@@ -275,7 +268,6 @@ class ArmGnuToolchain(ConanFile):
     def package_id(self):
         del self.info.options.local_path
         del self.info.options.default_arch
-        del self.info.options.default_specs
         del self.info.options.lto
         del self.info.options.fat_lto
         del self.info.options.function_sections

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,3 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(demo LANGUAGES CXX)
 add_executable(demo main.cpp)
+
+# Needed to link in low level C APIs
+target_link_options(demo PRIVATE --specs=nano.specs --specs=nosys.specs)


### PR DESCRIPTION
The default specs served to make test_packages easier to write as it would provide the necessary libc flags to link a binary completely.