### PR TITLE
Only inject nosys.specs, remove nano.specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,12 @@ flag `--gc_sections` to the linker arguments.
 ### `default_libc` (Default: `True`)
 
 This option can be `True` or `False` and when set to `True` will inject the
-flags `--specs=nano.specs` and `--specs=nosys.specs` to the linker arguments
-in order to link against the nano and nosys libc libraries. Disable this if
-your application would like to link against a different libc implementation.
+flag `--specs=nosys.specs` to the linker arguments. `nosys`  provides weak
+stubs for newlib libc APIs like `exit()`, `kill()`, `sbrk()` etc. This allows
+binaries to be linked without having to define all of the newlib libc
+definitions up front. It is UB to call any of these APIs without adding the
+necessary libc APIs. This is set to True in order to allow conan test_packages
+to link binaries. It is not advised to depend on `libc` for C API definitions.
 
 ## ✨ Adding New Versions of GCC
 

--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -23,7 +23,6 @@ class ArmGnuToolchain(ConanFile):
     exports_sources = "toolchain.cmake"
     package_type = "application"
     build_policy = "missing"
-    short_paths = True
     options = {
         "local_path": ["ANY"],
         "default_arch": [True, False],
@@ -54,7 +53,7 @@ class ArmGnuToolchain(ConanFile):
         "function_sections": "Enable -ffunction-sections which splits each function into their own subsection allowing link time garbage collection of the sections.",
         "data_sections": "Enable -fdata-sections which splits each statically defined block memory into their own subsection allowing link time garbage collection of the sections.",
         "gc_sections": "Enable garbage collection at link stage. Only useful if at least function_sections and data_sections is enabled.",
-        "default_libc": "Provide --specs=nano and --specs=nosys libc libraries for the linker in order to generate a binary. Disable this if your application would like to link against a different libc implementation."
+        "default_libc": "Link against `nosys` libc specification. This injects the `--specs=nosys.specs` argument to the linker during link. `nosys`  provides weak stubs for newlib libc APIs like exit(), kill(), sbrk() etc. This allows binaries to be linked without having to define all of the newlib libc definitions up front. It is UB to call any of these APIs without adding the necessary libc APIs. This is set to True in order to allow test_packages to link. It is not advised to depend on `libc` for C API definitions."
     }
 
     LOCAL_PATH_TXT = "local_path.txt"
@@ -218,8 +217,7 @@ class ArmGnuToolchain(ConanFile):
             exelinkflags.append("-Wl,--gc-sections")
 
         if self.options.default_libc:
-            exelinkflags.append("--specs=nano.specs ")
-            exelinkflags.append("--specs=nosys.specs ")
+            exelinkflags.append("--specs=nosys.specs")
 
         ARCH_MAP = {
             "cortex-m0": ["-mcpu=cortex-m0", "-mfloat-abi=soft"],
@@ -271,3 +269,4 @@ class ArmGnuToolchain(ConanFile):
         del self.info.options.function_sections
         del self.info.options.data_sections
         del self.info.options.gc_sections
+        del self.info.options.default_libc


### PR DESCRIPTION
Just to document this here further. `nano.specs` has strong symbols and will be in conflict with any other libc that is injected at link time. But nosys should only contains weak symbols allow us to link but not interfering with the injected libc. This should solve a key issue with the arm-gnu-toolchain and supporting conan test_packages. In the future, if we find a toolchain that doesn't provide low level libc APIs and doesn't have a `nosys.spec`, we should create our own simply to allow things to link. 