### PR TITLE
🚀 Add major version support and flexible binary compatibility profiles

### DIFF
--- a/.github/workflows/11.yml
+++ b/.github/workflows/11.yml
@@ -1,0 +1,12 @@
+name: 🚀 11 Deploy
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/verify_and_upload.yml
+    with:
+      version: "11"
+    secrets: inherit

--- a/.github/workflows/12.yml
+++ b/.github/workflows/12.yml
@@ -1,0 +1,12 @@
+name: 🚀 12 Deploy
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/verify_and_upload.yml
+    with:
+      version: "12"
+    secrets: inherit

--- a/.github/workflows/13.yml
+++ b/.github/workflows/13.yml
@@ -1,0 +1,12 @@
+name: 🚀 13 Deploy
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/verify_and_upload.yml
+    with:
+      version: "13"
+    secrets: inherit

--- a/.github/workflows/14.yml
+++ b/.github/workflows/14.yml
@@ -1,0 +1,12 @@
+name: 🚀 14 Deploy
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/verify_and_upload.yml
+    with:
+      version: "14"
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,11 +25,17 @@ jobs:
   ci_11_3:
     uses: ./.github/workflows/11.3.yml
     secrets: inherit
+  ci_11:
+    uses: ./.github/workflows/11.yml
+    secrets: inherit
   ci_12_2:
     uses: ./.github/workflows/12.2.yml
     secrets: inherit
   ci_12_3:
     uses: ./.github/workflows/12.3.yml
+    secrets: inherit
+  ci_12:
+    uses: ./.github/workflows/12.yml
     secrets: inherit
   ci_13_2:
     uses: ./.github/workflows/13.2.yml
@@ -37,9 +43,15 @@ jobs:
   ci_13_3:
     uses: ./.github/workflows/13.3.yml
     secrets: inherit
+  ci_13:
+    uses: ./.github/workflows/13.yml
+    secrets: inherit
   ci_14_2:
     uses: ./.github/workflows/14.2.yml
     secrets: inherit
   ci_14_3:
     uses: ./.github/workflows/14.3.yml
+    secrets: inherit
+  ci_14:
+    uses: ./.github/workflows/14.yml
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@ compiled using this toolchain.
 
 Supported version:
 
+- GCC 11 (alias for 11.3)
 - GCC 11.3
+- GCC 12 (alias for 12.3)
 - GCC 12.2
 - GCC 12.3
+- GCC 13 (alias for 13.3)
 - GCC 13.2
 - GCC 13.3
+- GCC 14 (alias for 14.3)
 - GCC 14.2
+- GCC 14.3
 
 Supported Architectures:
 
@@ -131,6 +136,24 @@ should be incremented if the behavior of the profiles changes significantly
 enough to break current applications.
 
 All profiles use `libstdc++11` as this is the latest GCC C++ ABI.
+
+### Profile Naming Scheme
+
+**Broad Compatibility Profiles** (Recommended):
+
+- Format: `arm-gcc-X` or `arm-gcc-X.Y`
+- Example: `arm-gcc-12`, `arm-gcc-12.2`, `arm-gcc-12.3`
+- Behavior: Uses `compiler.version=X` (major version only)
+- All GCC 12.x profiles use `compiler.version=12`, making binaries compatible across minor versions
+- Use these for maximum flexibility - binaries built with `arm-gcc-12.2` work with `arm-gcc-12.3`
+
+**Exact Version Profiles**:
+
+- Format: `arm-gcc-X.Y-exact`
+- Example: `arm-gcc-12.3-exact`
+- Behavior: Uses `compiler.version=X.Y` (exact version)
+- Requires strict version matching - binaries built with GCC 12.3 won't mix with GCC 12.2
+- Use only when you need strict ABI guarantees
 
 ## 📦 Building & Installing the Tool Package
 

--- a/all/conandata.yml
+++ b/all/conandata.yml
@@ -18,6 +18,25 @@ sources:
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
         sha256: "23f24595aa575fba4fdb0cb086df4b053862af60837502cb7e52bd4fb3d76c36"
+  "11":
+    "Linux":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
+        sha256: "d420d87f68615d9163b99bbb62fe69e85132dc0a8cd69fca04e813597fe06121"
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-aarch64-arm-none-eabi.tar.xz"
+        sha256: "6c713c11d018dcecc16161f822517484a13af151480bbb722badd732412eb55e"
+    "Macos":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
+        sha256: "826353d45e7fbaa9b87c514e7c758a82f349cb7fc3fd949423687671539b29cf"
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
+        sha256: "826353d45e7fbaa9b87c514e7c758a82f349cb7fc3fd949423687671539b29cf"
+    "Windows":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
+        sha256: "23f24595aa575fba4fdb0cb086df4b053862af60837502cb7e52bd4fb3d76c36"
   "12.2":
     "Linux":
       "x86_64":
@@ -38,6 +57,25 @@ sources:
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi.zip"
         sha256: "ad1427496cde9bbe7604bc448ec6e115c6538e04af1c8275795ebb1c2b7b2830"
   "12.3":
+    "Linux":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz"
+        sha256: "12a2815644318ebcceaf84beabb665d0924b6e79e21048452c5331a56332b309"
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-aarch64-arm-none-eabi.tar.xz"
+        sha256: "14c0487d5753f6071d24e568881f7c7e67f80dd83165dec5164b3731394af431"
+    "Macos":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
+        sha256: "e6ed8bf930fad9ce33e120ab90b36957b1f779fccaa6de6c9ca9a58982c04291"
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-darwin-arm64-arm-none-eabi.tar.xz"
+        sha256: "3b2eee0bdf71c1bbeb3c3b7424fbf7bd9d5c3f0f5a3a4a78159c9e3ad219e7bd"
+    "Windows":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
+        sha256: "d52888bf59c5262ebf3e6b19b9f9e6270ecb60fd218cf81a4e793946e805a654"
+  "12":
     "Linux":
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz"
@@ -94,6 +132,25 @@ sources:
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
         sha256: "e46fda043c0ce83582bc8db4b3ef85f77f4beb7333344c2f4193c17e1167a095"
+  "13":
+    "Linux":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz"
+        sha256: "95c011cee430e64dd6087c75c800f04b9c49832cc1000127a92a97f9c8d83af4"
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-aarch64-arm-none-eabi.tar.xz"
+        sha256: "c8824bffd057afce2259f7618254e840715f33523a3d4e4294f471208f976764"
+    "Macos":
+      x86_64:
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz"
+        sha256: "1ab00742d1ed0926e6f227df39d767f8efab46f5250505c29cb81f548222d794"
+      armv8:
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi.tar.xz"
+        sha256: "fb6921db95d345dc7e5e487dd43b745e3a5b4d5c0c7ca4f707347148760317b4"
+    "Windows":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-mingw-w64-i686-arm-none-eabi.zip"
+        sha256: "e46fda043c0ce83582bc8db4b3ef85f77f4beb7333344c2f4193c17e1167a095"
   "14.2":
     "Linux":
       "x86_64":
@@ -114,6 +171,22 @@ sources:
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-mingw-w64-i686-arm-none-eabi.zip"
         sha256: "6facb152ce431ba9a4517e939ea46f057380f8f1e56b62e8712b3f3b87d994e1"
   "14.3":
+    "Linux":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz"
+        sha256: "62a63b981fe391a9cbad7ef51b17e49aeaa3e7b0d029b36ca1e9c3b2a9b78823"
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-aarch64-arm-none-eabi.tar.xz"
+        sha256: "2d465847eb1d05f876270494f51034de9ace9abe87a4222d079f3360240184d3"
+    "Macos":
+      "armv8":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-darwin-arm64-arm-none-eabi.tar.xz"
+        sha256: "30f4d08b219190a37cded6aa796f4549504902c53cfc3c7e044a8490b6eba1f7"
+    "Windows":
+      "x86_64":
+        url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-mingw-w64-x86_64-arm-none-eabi.zip"
+        sha256: "864c0c8815857d68a1bbba2e5e2782255bb922845c71c97636004a3d74f60986"
+  "14":
     "Linux":
       "x86_64":
         url: "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz"

--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -105,12 +105,16 @@ class ArmGnuToolchain(ConanFile):
             # https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
             # web page.
             "11.3": "https://developer.arm.com/GetEula?Id=ff19df33-da82-491a-ab50-c605d4589a26",
+            "11": "https://developer.arm.com/GetEula?Id=ff19df33-da82-491a-ab50-c605d4589a26",
             "12.2": "https://developer.arm.com/GetEula?Id=2821586b-44d0-4e75-a06d-4279cd97eaae",
             "12.3": "https://developer.arm.com/GetEula?Id=aa3d692d-bc99-4c8c-bce2-588181ddde13",
+            "12": "https://developer.arm.com/GetEula?Id=aa3d692d-bc99-4c8c-bce2-588181ddde13",
             "13.2": "https://developer.arm.com/GetEula?Id=37988a7c-c40e-4b78-9fd1-62c20b507aa8",
             "13.3": "https://developer.arm.com/GetEula?Id=d023c29f-8e81-49b0-979f-a5610ea2ccbb",
+            "13": "https://developer.arm.com/GetEula?Id=d023c29f-8e81-49b0-979f-a5610ea2ccbb",
             "14.2": "https://developer.arm.com/GetEula?Id=3aa52a53-d1cb-414b-b540-eaf29fdef0ca",
             "14.3": "https://developer.arm.com/GetEula?Id=15d9660a-2059-4985-85e9-c01cdd4b1ba0",
+            "14": "https://developer.arm.com/GetEula?Id=15d9660a-2059-4985-85e9-c01cdd4b1ba0",
         }
 
         if self.version in VERSION_MAP:
@@ -122,8 +126,9 @@ class ArmGnuToolchain(ConanFile):
 
         # For some reason ARM decided to make this version have a different
         # folder layout compared to others so we need a special case for this.
-        should_strip_root = not ((VERSION == "14.2" or VERSION == "14.3")
-                                 and OS == "Windows" and ARCH == "x86_64")
+        should_strip_root = not (
+            (VERSION == "14.2" or VERSION == "14.3" or VERSION == "14")
+            and OS == "Windows" and ARCH == "x86_64")
         get(self,
             **self.conan_data["sources"][self.version][OS][ARCH],
             destination=self.package_folder, strip_root=should_strip_root)

--- a/conan/profiles/v1/arm-gcc-11
+++ b/conan/profiles/v1/arm-gcc-11
@@ -5,4 +5,4 @@ compiler.libcxx=libstdc++11
 compiler.version=11
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/11

--- a/conan/profiles/v1/arm-gcc-11.3-exact
+++ b/conan/profiles/v1/arm-gcc-11.3-exact
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=11.3
 
 [tool_requires]
 arm-gnu-toolchain/11.3

--- a/conan/profiles/v1/arm-gcc-12
+++ b/conan/profiles/v1/arm-gcc-12
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=12
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/12

--- a/conan/profiles/v1/arm-gcc-12.2
+++ b/conan/profiles/v1/arm-gcc-12.2
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=12.2
+compiler.version=12
 
 [tool_requires]
 arm-gnu-toolchain/12.2

--- a/conan/profiles/v1/arm-gcc-12.2-exact
+++ b/conan/profiles/v1/arm-gcc-12.2-exact
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=12.2
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/12.2

--- a/conan/profiles/v1/arm-gcc-12.3
+++ b/conan/profiles/v1/arm-gcc-12.3
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=12.3
+compiler.version=12
 
 [tool_requires]
 arm-gnu-toolchain/12.3

--- a/conan/profiles/v1/arm-gcc-12.3-exact
+++ b/conan/profiles/v1/arm-gcc-12.3-exact
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=12.3
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/12.3

--- a/conan/profiles/v1/arm-gcc-13
+++ b/conan/profiles/v1/arm-gcc-13
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=13
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/13

--- a/conan/profiles/v1/arm-gcc-13.2
+++ b/conan/profiles/v1/arm-gcc-13.2
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=13.2
+compiler.version=13
 
 [tool_requires]
 arm-gnu-toolchain/13.2

--- a/conan/profiles/v1/arm-gcc-13.2-exact
+++ b/conan/profiles/v1/arm-gcc-13.2-exact
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=13.2
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/13.2

--- a/conan/profiles/v1/arm-gcc-13.3
+++ b/conan/profiles/v1/arm-gcc-13.3
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=13.3
+compiler.version=13
 
 [tool_requires]
 arm-gnu-toolchain/13.3

--- a/conan/profiles/v1/arm-gcc-13.3-exact
+++ b/conan/profiles/v1/arm-gcc-13.3-exact
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=13.3
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/13.3

--- a/conan/profiles/v1/arm-gcc-14
+++ b/conan/profiles/v1/arm-gcc-14
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=14
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/14

--- a/conan/profiles/v1/arm-gcc-14.2
+++ b/conan/profiles/v1/arm-gcc-14.2
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=14.2
+compiler.version=14
 
 [tool_requires]
 arm-gnu-toolchain/14.2

--- a/conan/profiles/v1/arm-gcc-14.2-exact
+++ b/conan/profiles/v1/arm-gcc-14.2-exact
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=14.2
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/14.2

--- a/conan/profiles/v1/arm-gcc-14.3
+++ b/conan/profiles/v1/arm-gcc-14.3
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=14.3
+compiler.version=14
 
 [tool_requires]
 arm-gnu-toolchain/14.3

--- a/conan/profiles/v1/arm-gcc-14.3-exact
+++ b/conan/profiles/v1/arm-gcc-14.3-exact
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11
+compiler.version=14.3
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/14.3


### PR DESCRIPTION
This PR introduces major version aliases and a new profile naming scheme
that provides flexibility in binary compatibility while maintaining strict
version control when needed.

Changes:
- Add major version support (11, 12, 13, 14) as aliases to latest minor versions
- Add workflow files for deploying major versions (11.yml, 12.yml, 13.yml, 14.yml)
- Update deploy.yml to include major version CI jobs
- Add conandata.yml entries for major versions pointing to latest minor releases
- Update conanfile.py to handle major version EULAs and Windows folder layout

Profile improvements:
- Add major version profiles (arm-gcc-11, arm-gcc-12, arm-gcc-13, arm-gcc-14)
- Update all minor version profiles to use major compiler.version for broad compatibility
  (e.g., arm-gcc-12.2 and arm-gcc-12.3 both use compiler.version=12)
- Add -exact variant profiles for strict version matching when needed
  (e.g., arm-gcc-12.3-exact uses compiler.version=12.3)

This allows binaries built with different minor versions of the same major
version to be compatible by default, while providing escape hatches for
users who need exact version matching.

Documentation:
- Update README with new profile naming scheme
- Add guidance on when to use broad vs exact compatibility profiles
